### PR TITLE
Fix Windows build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,8 @@ if(UNIX)
     endif()
 elseif(MSVC)
     target_link_libraries(NtRays
-        ${IDA_SDK_DIR}/lib/x64_win_vc_64/ida.lib
-        ${IDA_SDK_DIR}/lib/x64_win_vc_64_s/pro.lib
+        ${IDA_SDK_DIR}/lib/x64_win_vc_64/ida
+        ${IDA_SDK_DIR}/lib/x64_win_vc_64_s/pro
     )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ NtRays is a Hex-Rays microcode plugin for automated simplification of Windows Ke
 
 ### Windows with Visual Studio 2022
 
+Place a copy of idasdk90 in the root directory of NtRays as well as in the build folder.
+
 ```
 mkdir build
 cd build
-cmake -G "Visual Studio 17 2022" -A x64 .. -DIDA_SDK_DIR=idasdk90 -DHEXRAYS_SDK_DIR=C:\Program Files\IDA Professional 9.0\plugins\hexrays_sdk
+cmake -G "Visual Studio 17 2022" -A x64 .. -DIDA_SDK_DIR=idasdk90 -DHEXRAYS_SDK_DIR=idasdk90
 cmake --build . --config Release
 ```
 

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -1577,12 +1577,18 @@ State: %s)";
         // Determine the state text based on nn.altval(0)
         const char* state_text = (nn.altval(0) == 0) ? "Enabled" : "Disabled";
 
-        int code = ask_buttons( "~E~nable", "~D~isable", "~C~lose", -1, format + 1, state_text );
-        if ( code < 0 )
-            return true;
+		int code = ask_buttons( "~E~nable", "~D~isable", "~C~lose", -1, format + 1, state_text );
+		if ( code < 0 )
+			return true;
 
-        nn.altset( 0, code ? 0 : 1 );
-        set_state( code == 0 ); // If code is 0, enable the plugin (set to true)
+		// Fix the logic so that the "Enable" button sets the plugin state to true
+		if (code == 0) {
+			nn.altset( 0, 0 );  // Set to "enabled"
+			set_state(true);     // Enable the plugin
+		} else if (code == 1) {
+			nn.altset( 0, 1 );  // Set to "disabled"
+			set_state(false);    // Disable the plugin
+		}
 
         return true;
     }

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -1547,14 +1547,9 @@ struct ntrays : plugmod_t
 
     ntrays()
     {
-        // Define a buffer to store the file type name
-        char file_type[256] = {0};
-        
-        // Get the file type name and store it in the buffer
-        size_t size = get_file_type_name(file_type, sizeof(file_type));
 
         // Only automatically enable if the binary is a Windows (PE) file
-        if (size > 0 && strstr(file_type, "PE") != nullptr && nn.altval(0) == 0)
+        if (inf_get_filetype() == f_PE && nn.altval(0) == 0)
         {
 			nn.altset( 0, 0 ); // Set plugin state to "enabled"
             set_state(true);

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -1553,18 +1553,14 @@ struct ntrays : plugmod_t
         // Get the file type name and store it in the buffer
         size_t size = get_file_type_name(file_type, sizeof(file_type));
 
-        msg("[NtRays] Da size is: %d\n", size);
-        msg("[NtRays] Da string is: %s\n", file_type);
         
         // Only automatically enable if the binary is a Windows (PE) file
         if (size > 0 && strstr(file_type, "PE") != nullptr && nn.altval(0) == 0)
         {
-            msg("[NtRays] set_state(true)\n");
             set_state(true);
         }
         else
         {
-            msg("[NtRays] set_state(false)\n");
             set_state(false);
         }
     }

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -1553,14 +1553,15 @@ struct ntrays : plugmod_t
         // Get the file type name and store it in the buffer
         size_t size = get_file_type_name(file_type, sizeof(file_type));
 
-        
         // Only automatically enable if the binary is a Windows (PE) file
         if (size > 0 && strstr(file_type, "PE") != nullptr && nn.altval(0) == 0)
         {
+			nn.altset( 0, 0 ); // Set plugin state to "enabled"
             set_state(true);
         }
         else
         {
+			nn.altset( 0, 1 ); // Set plugin state to "disabled"
             set_state(false);
         }
     }
@@ -1581,11 +1582,10 @@ State: %s)";
 		if ( code < 0 )
 			return true;
 
-		// Fix the logic so that the "Enable" button sets the plugin state to true
-		if (code == 0) {
+		if (code == 1) {
 			nn.altset( 0, 0 );  // Set to "enabled"
 			set_state(true);     // Enable the plugin
-		} else if (code == 1) {
+		} else if (code == 0) {
 			nn.altset( 0, 1 );  // Set to "disabled"
 			set_state(false);    // Disable the plugin
 		}


### PR DESCRIPTION
When building NtRays for Windows, it tries to link against "idasdk90\lib\x64_win_vc_64\ida.lib.lib" which does not exist. Removing the .lib suffix in CMakeLists fixes the problem.

I have also updated the build instructions to make it easier to build the plugin.